### PR TITLE
fix(helm): grant PostgreSQL 15+ public schema permissions in database init

### DIFF
--- a/infra/helm/bud/templates/extra/postgres.yaml
+++ b/infra/helm/bud/templates/extra/postgres.yaml
@@ -15,6 +15,8 @@ data:
     {{- range $.Values.postgresqlExtra.autoCreateDB }}
       CREATE USER {{ . }} WITH PASSWORD '{{ . }}';
       CREATE DATABASE {{ . }} OWNER {{ . }};
+      \c {{ . }}
+      GRANT ALL ON SCHEMA public TO {{ . }};
     {{- end }}
     EOF
 ---


### PR DESCRIPTION
## Summary
- Fixed PostgreSQL 15+ permission issue that was preventing budmodel (and potentially other services) from running migrations
- Added `GRANT ALL ON SCHEMA public` to the database initialization Job

## Problem
PostgreSQL 15 changed the default permissions on the `public` schema. The database initialization Job creates databases and users but doesn't grant CREATE permission on the public schema, causing migrations to fail with:
```
psycopg.errors.InsufficientPrivilege: permission denied for schema public
```

## Solution
Modified `infra/helm/bud/templates/extra/postgres.yaml` to grant permissions after creating each database:
```sql
CREATE USER {{ . }} WITH PASSWORD '{{ . }}';
CREATE DATABASE {{ . }} OWNER {{ . }};
\c {{ . }}
GRANT ALL ON SCHEMA public TO {{ . }};
```

## Impact
- Fixes the immediate budmodel migration failure
- Prevents the same issue for all other services (budapp, budcluster, budsim, budmetrics, askbud)
- Ensures compatibility with PostgreSQL 15+

## Test Plan
- [ ] Apply the fix to existing PostgreSQL instance
- [ ] Verify budmodel can run migrations successfully
- [ ] Confirm other services continue to work properly
- [ ] Test fresh deployment with the updated Helm chart

🤖 Generated with [Claude Code](https://claude.ai/code)