### PR TITLE
feat: add project_type field to Project table

### DIFF
--- a/services/budapp/budapp/commons/constants.py
+++ b/services/budapp/budapp/commons/constants.py
@@ -852,6 +852,20 @@ class ProjectStatusEnum(StrEnum):
     DELETED = auto()
 
 
+class ProjectTypeEnum(StrEnum):
+    """Enumeration of project types in the system.
+
+    This enum defines the different types of projects that can exist in the Bud ecosystem.
+
+    Attributes:
+        CLIENT_APP: Represents a client application project.
+        ADMIN_APP: Represents an admin application project.
+    """
+
+    CLIENT_APP = auto()
+    ADMIN_APP = auto()
+
+
 # Bud Notify Workflow
 BUD_NOTIFICATION_WORKFLOW = "bud-notification"
 BUD_INTERNAL_WORKFLOW = "bud-internal"

--- a/services/budapp/budapp/migrations/versions/20250806170226_6c153255_add_project_type_to_project_table.py
+++ b/services/budapp/budapp/migrations/versions/20250806170226_6c153255_add_project_type_to_project_table.py
@@ -1,0 +1,47 @@
+"""add project_type to project table
+
+Revision ID: 20250806170226_6c153255
+Revises: 20250730155527
+Create Date: 2025-08-06 17:02:26.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250806170226_6c153255"
+down_revision: Union[str, None] = "20250730155527"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create the project_type_enum type
+    sa.Enum("client_app", "admin_app", name="project_type_enum").create(op.get_bind())
+
+    # Add project_type column to project table with default value
+    op.add_column(
+        "project",
+        sa.Column(
+            "project_type",
+            postgresql.ENUM("client_app", "admin_app", name="project_type_enum", create_type=False),
+            nullable=False,
+            server_default="client_app",
+        ),
+    )
+
+    # Remove the server default after setting existing rows
+    op.alter_column("project", "project_type", server_default=None)
+
+
+def downgrade() -> None:
+    # Drop the project_type column
+    op.drop_column("project", "project_type")
+
+    # Drop the enum type
+    sa.Enum("client_app", "admin_app", name="project_type_enum").drop(op.get_bind())

--- a/services/budapp/budapp/project_ops/models.py
+++ b/services/budapp/budapp/project_ops/models.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from budapp.commons.database import Base, TimestampMixin
 from budapp.permissions.models import ProjectPermission
 
-from ..commons.constants import ProjectStatusEnum
+from ..commons.constants import ProjectStatusEnum, ProjectTypeEnum
 from ..permissions.models import ProjectPermission
 
 
@@ -55,6 +55,15 @@ class Project(Base, TimestampMixin):
         ),
         nullable=False,
         default=ProjectStatusEnum.ACTIVE,
+    )
+    project_type: Mapped[str] = mapped_column(
+        Enum(
+            ProjectTypeEnum,
+            name="project_type_enum",
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=False,
+        default=ProjectTypeEnum.CLIENT_APP,
     )
     benchmark: Mapped[bool] = mapped_column(Boolean, default=False)
     created_by: Mapped[UUID] = mapped_column(ForeignKey("user.id"), nullable=False)

--- a/services/budapp/budapp/project_ops/schemas.py
+++ b/services/budapp/budapp/project_ops/schemas.py
@@ -32,7 +32,7 @@ from pydantic import (
 
 from budapp.commons.schemas import PaginatedSuccessResponse, SuccessResponse, Tag
 
-from ..commons.constants import ClusterStatusEnum, PermissionEnum, UserStatusEnum
+from ..commons.constants import ClusterStatusEnum, PermissionEnum, ProjectTypeEnum, UserStatusEnum
 from ..commons.helpers import validate_icon
 from ..permissions.schemas import PermissionList
 from ..user_ops.schemas import UserInfo
@@ -43,6 +43,7 @@ class ProjectBase(BaseModel):
     description: str | None = None
     tags: List[Tag] | None = None
     icon: str | None = None
+    project_type: ProjectTypeEnum | None = Field(default=ProjectTypeEnum.CLIENT_APP)
 
 
 # class ProjectRequest(ProjectBase):
@@ -66,6 +67,7 @@ class EditProjectRequest(BaseModel):
     description: str | None = Field(None, max_length=400)
     tags: List[Tag] | None = None
     icon: str | None = None
+    project_type: ProjectTypeEnum | None = None
 
     @field_validator("name", mode="before")
     @classmethod
@@ -172,6 +174,7 @@ class Project(ProjectBase):
 
 class ProjectCreateRequest(ProjectBase):
     benchmark: bool = False
+    project_type: ProjectTypeEnum = Field(default=ProjectTypeEnum.CLIENT_APP)
 
 
 class ProjectFilter(BaseModel):

--- a/services/budapp/tests/test_project_type.py
+++ b/services/budapp/tests/test_project_type.py
@@ -1,0 +1,177 @@
+"""Unit tests for project_type field functionality."""
+
+from uuid import uuid4
+
+import pytest
+
+from budapp.commons.constants import ProjectTypeEnum
+from budapp.project_ops.models import Project
+from budapp.project_ops.schemas import (
+    EditProjectRequest,
+    ProjectBase,
+    ProjectCreateRequest,
+    ProjectResponse,
+)
+
+
+class TestProjectTypeEnum:
+    """Test ProjectTypeEnum functionality."""
+
+    def test_project_type_enum_values(self):
+        """Test that ProjectTypeEnum has correct values."""
+        assert ProjectTypeEnum.CLIENT_APP.value == "client_app"
+        assert ProjectTypeEnum.ADMIN_APP.value == "admin_app"
+
+    def test_project_type_enum_members(self):
+        """Test that ProjectTypeEnum has all required members."""
+        members = list(ProjectTypeEnum)
+        assert len(members) == 2
+        assert ProjectTypeEnum.CLIENT_APP in members
+        assert ProjectTypeEnum.ADMIN_APP in members
+
+
+class TestProjectSchemas:
+    """Test Pydantic schemas with project_type field."""
+
+    def test_project_base_schema_with_project_type(self):
+        """Test ProjectBase schema accepts project_type."""
+        project_data = {
+            "name": "Test Project",
+            "description": "Test Description",
+            "project_type": ProjectTypeEnum.ADMIN_APP,
+        }
+        project = ProjectBase(**project_data)
+        assert project.project_type == ProjectTypeEnum.ADMIN_APP
+
+    def test_project_base_schema_default_project_type(self):
+        """Test ProjectBase schema uses default project_type."""
+        project_data = {
+            "name": "Test Project",
+            "description": "Test Description",
+        }
+        project = ProjectBase(**project_data)
+        assert project.project_type == ProjectTypeEnum.CLIENT_APP
+
+    def test_project_create_request_with_project_type(self):
+        """Test ProjectCreateRequest accepts project_type."""
+        project_data = {
+            "name": "Test Project",
+            "description": "Test Description",
+            "benchmark": True,
+            "project_type": ProjectTypeEnum.ADMIN_APP,
+        }
+        project = ProjectCreateRequest(**project_data)
+        assert project.project_type == ProjectTypeEnum.ADMIN_APP
+        assert project.benchmark is True
+
+    def test_project_create_request_default_project_type(self):
+        """Test ProjectCreateRequest uses default project_type."""
+        project_data = {
+            "name": "Test Project",
+            "description": "Test Description",
+        }
+        project = ProjectCreateRequest(**project_data)
+        assert project.project_type == ProjectTypeEnum.CLIENT_APP
+        assert project.benchmark is False
+
+    def test_edit_project_request_with_project_type(self):
+        """Test EditProjectRequest accepts project_type."""
+        edit_data = {
+            "name": "Updated Project",
+            "project_type": ProjectTypeEnum.ADMIN_APP,
+        }
+        edit_request = EditProjectRequest(**edit_data)
+        assert edit_request.project_type == ProjectTypeEnum.ADMIN_APP
+        assert edit_request.name == "Updated Project"
+
+    def test_edit_project_request_optional_project_type(self):
+        """Test EditProjectRequest with optional project_type."""
+        edit_data = {
+            "name": "Updated Project",
+        }
+        edit_request = EditProjectRequest(**edit_data)
+        assert edit_request.project_type is None
+        assert edit_request.name == "Updated Project"
+
+    def test_project_response_includes_project_type(self):
+        """Test ProjectResponse includes project_type field."""
+        project_data = {
+            "id": uuid4(),
+            "name": "Test Project",
+            "description": "Test Description",
+            "project_type": ProjectTypeEnum.ADMIN_APP,
+        }
+        response = ProjectResponse(**project_data)
+        assert response.project_type == ProjectTypeEnum.ADMIN_APP
+        assert response.name == "Test Project"
+
+    def test_invalid_project_type_raises_error(self):
+        """Test that invalid project_type raises validation error."""
+        with pytest.raises(ValueError):
+            ProjectCreateRequest(
+                name="Test Project",
+                project_type="invalid_type",  # Invalid enum value
+            )
+
+
+class TestProjectModel:
+    """Test Project model with project_type field."""
+
+    def test_project_model_default_project_type(self):
+        """Test that Project model has correct default project_type."""
+        # This test verifies that the model is configured correctly
+        # The actual database test would require a database session
+        project = Project(
+            name="Test Project",
+            description="Test Description",
+            created_by=uuid4(),
+        )
+        # The default should be set at the database level
+        # This is more of a model configuration check
+        assert hasattr(project, "project_type")
+
+    def test_project_model_with_project_type(self):
+        """Test Project model accepts project_type."""
+        project = Project(
+            name="Test Project",
+            description="Test Description",
+            created_by=uuid4(),
+            project_type=ProjectTypeEnum.ADMIN_APP.value,
+        )
+        assert project.project_type == ProjectTypeEnum.ADMIN_APP.value
+
+
+class TestBackwardCompatibility:
+    """Test backward compatibility of project_type field."""
+
+    def test_create_project_without_project_type(self):
+        """Test creating project without specifying project_type."""
+        project_data = {
+            "name": "Legacy Project",
+            "description": "Created without project_type",
+        }
+        project = ProjectCreateRequest(**project_data)
+        # Should default to CLIENT_APP
+        assert project.project_type == ProjectTypeEnum.CLIENT_APP
+
+    def test_edit_project_without_changing_project_type(self):
+        """Test editing project without changing project_type."""
+        edit_data = {
+            "name": "Updated Name",
+            "description": "Updated Description",
+        }
+        edit_request = EditProjectRequest(**edit_data)
+        # project_type should be None (not changed)
+        assert edit_request.project_type is None
+
+    def test_project_response_backward_compatibility(self):
+        """Test that ProjectResponse works with legacy data."""
+        # Simulate legacy project data without project_type
+        project_data = {
+            "id": uuid4(),
+            "name": "Legacy Project",
+            "description": "Old project",
+            "project_type": ProjectTypeEnum.CLIENT_APP,  # Default value
+        }
+        response = ProjectResponse(**project_data)
+        assert response.project_type == ProjectTypeEnum.CLIENT_APP


### PR DESCRIPTION
## Summary
- Added `project_type` field to Project table to distinguish between different types of projects (CLIENT_APP and ADMIN_APP)
- Implemented with full backward compatibility - existing projects default to CLIENT_APP
- Includes comprehensive unit tests and database migration

## Changes Made

### 1. Database Schema Changes
- Created `ProjectTypeEnum` in `budapp/commons/constants.py` with two values: CLIENT_APP and ADMIN_APP
- Added `project_type` column to Project model in `budapp/project_ops/models.py`
- Generated Alembic migration to add the new column with proper enum type

### 2. API Updates
- Updated Pydantic schemas in `budapp/project_ops/schemas.py`:
  - `ProjectBase`: Added optional `project_type` field with CLIENT_APP default
  - `ProjectCreateRequest`: Added `project_type` field for project creation
  - `EditProjectRequest`: Added optional `project_type` for project updates
  - All response schemas now include the `project_type` field

### 3. Testing
- Added comprehensive unit tests in `tests/test_project_type.py`:
  - Enum value validation tests
  - Schema validation and default value tests
  - Model configuration tests
  - Backward compatibility tests
  - Invalid value validation tests

### 4. Migration Details
- Migration ID: `20250806170226_6c153255`
- Creates PostgreSQL enum type `project_type_enum`
- Adds `project_type` column with default value `client_app`
- All existing projects will automatically have `project_type = client_app`

## Backward Compatibility
✅ **Fully backward compatible**
- Existing projects default to CLIENT_APP type
- API endpoints continue to work without specifying project_type
- No breaking changes to existing functionality

## Testing Done
- ✅ Unit tests for enum values and validation
- ✅ Schema validation tests
- ✅ Backward compatibility tests
- ✅ Code linting with Ruff
- ✅ Type checking with MyPy
- ✅ Pre-commit hooks passed

## References
- Closes #72
- Linear Issue: [BUD-357](https://linear.app/bud-ecosystem/issue/BUD-357/backend-database-schema-add-project-type-field)

## Migration Instructions
After merging, run the following command to apply the migration:
```bash
alembic -c ./budapp/alembic.ini upgrade head
```

## Future Considerations
This foundation allows for:
- Project-type-specific business logic
- Different permission models per project type
- Filtered views based on project type
- Easy addition of new project types if needed