### PR TITLE
fix: encrypt API keys and credentials at rest for enhanced security

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,3 +438,5 @@ Complete API documentation available in `docs/api/inference-endpoints.md` coveri
 - Error handling
 - Rate limiting
 - Best practices
+
+- Don't save any keys as plain text in DBs. Always use encryption. Security is of high priority.

--- a/services/budadmin/src/components/ui/bud/drawer/BudDrawer.tsx
+++ b/services/budadmin/src/components/ui/bud/drawer/BudDrawer.tsx
@@ -80,6 +80,7 @@ const BudDrawer: React.FC = () => {
           }}
         >
           <step.component
+            {...step?.properties}
             {...drawerProps}
           />
         </BudFormContext.Provider>

--- a/services/budapp/budapp/credential_ops/models.py
+++ b/services/budapp/budapp/credential_ops/models.py
@@ -58,7 +58,7 @@ class Credential(Base, TimestampMixin):
     __tablename__ = "credential"
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
-    key: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    encrypted_key: Mapped[str] = mapped_column(String, nullable=False)  # Encrypted storage only
     project_id: Mapped[UUID] = mapped_column(ForeignKey("project.id", ondelete="CASCADE"), nullable=True)
     expiry: Mapped[datetime] = mapped_column(DateTime, nullable=True)
     max_budget: Mapped[float] = mapped_column(Float, nullable=True)
@@ -98,7 +98,7 @@ class CloudCredentials(Base, TimestampMixin):
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
     provider_id: Mapped[UUID] = mapped_column(ForeignKey("cloud_providers.id", ondelete="CASCADE"), nullable=False)
-    credential: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    encrypted_credential: Mapped[dict] = mapped_column(JSONB, nullable=False)  # Encrypted storage only
     credential_name: Mapped[str] = mapped_column(String, nullable=False, default="No Name")
 
     provider = relationship("CloudProviders", back_populates="credentials")

--- a/services/budapp/budapp/credential_ops/schemas.py
+++ b/services/budapp/budapp/credential_ops/schemas.py
@@ -58,7 +58,7 @@ class CredentialUpdateRequest(CloudEventBase):
 class CredentialBase(BaseModel):
     """Credential base schema."""
 
-    key: str
+    encrypted_key: str
 
 
 class CredentialCreate(CredentialBase):
@@ -74,9 +74,11 @@ class CredentialFilter(BaseModel):
     project_id: Optional[UUID] = None
 
 
-class BudCredentialCreate(CredentialCreate):
+class BudCredentialCreate(BaseModel):
     """Create credential schema."""
 
+    user_id: UUID
+    encrypted_key: str
     name: str
     project_id: UUID
     expiry: datetime | None

--- a/services/budapp/budapp/migrations/versions/65c3cfbe96c9_finalize_encrypted_credentials_remove_.py
+++ b/services/budapp/budapp/migrations/versions/65c3cfbe96c9_finalize_encrypted_credentials_remove_.py
@@ -1,0 +1,45 @@
+"""Finalize encrypted credentials - remove plain columns
+
+Revision ID: 65c3cfbe96c9
+Revises: c438aff47613
+Create Date: 2025-08-22 18:44:14.026275
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "65c3cfbe96c9"
+down_revision: Union[str, None] = "c438aff47613"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Make encrypted_key NOT NULL since all credentials should now be encrypted
+    op.alter_column("credential", "encrypted_key", existing_type=sa.String(), nullable=False)
+
+    # Make encrypted_credential NOT NULL since all cloud credentials should now be encrypted
+    op.alter_column("cloud_credentials", "encrypted_credential", existing_type=JSONB, nullable=False)
+
+    # Drop the plain key column - no longer needed
+    op.drop_column("credential", "key")
+
+    # Drop the plain credential column - no longer needed
+    op.drop_column("cloud_credentials", "credential")
+
+
+def downgrade() -> None:
+    # Re-add the plain columns for rollback capability
+    op.add_column("credential", sa.Column("key", sa.String(), nullable=True, unique=True))
+    op.add_column("cloud_credentials", sa.Column("credential", JSONB, nullable=True))
+
+    # Make encrypted columns nullable again
+    op.alter_column("credential", "encrypted_key", existing_type=sa.String(), nullable=True)
+
+    op.alter_column("cloud_credentials", "encrypted_credential", existing_type=JSONB, nullable=True)

--- a/services/budapp/budapp/migrations/versions/c438aff47613_add_encrypted_key_column_and_encrypt_.py
+++ b/services/budapp/budapp/migrations/versions/c438aff47613_add_encrypted_key_column_and_encrypt_.py
@@ -1,0 +1,37 @@
+"""Add encrypted_key column and encrypt credentials
+
+Revision ID: c438aff47613
+Revises: 6bce128f07e1
+Create Date: 2025-08-22 18:12:02.238311
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c438aff47613"
+down_revision: Union[str, None] = "6bce128f07e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add encrypted_key column to credential table
+    op.add_column("credential", sa.Column("encrypted_key", sa.String(), nullable=True))
+
+    # Add encrypted_credential column to cloud_credentials table
+    op.add_column("cloud_credentials", sa.Column("encrypted_credential", JSONB, nullable=True))
+
+    # Note: After deployment, run the data migration script to encrypt existing keys
+    # Then make encrypted_key NOT NULL and drop the plain key column
+
+
+def downgrade() -> None:
+    # Remove encrypted columns
+    op.drop_column("credential", "encrypted_key")
+    op.drop_column("cloud_credentials", "encrypted_credential")


### PR DESCRIPTION
## 🔒 Security Enhancement: Encrypt API Keys and Credentials

### 🚨 BREAKING CHANGE
API keys and cloud credentials are now encrypted in the database. **Migration required before deploying.**

### 📋 Summary
This PR addresses a critical security vulnerability where API keys and cloud provider credentials were stored in plain text in the database. All sensitive credentials are now encrypted using RSA encryption before storage.

### 🛡️ Security Improvements
- ✅ **RSA Encryption**: All API keys encrypted before database storage
- ✅ **Encrypted Cloud Credentials**: JSONB fields for cloud provider credentials now encrypted
- ✅ **Secure Lookups**: SHA-256 hashed keys enable validation without decryption
- ✅ **Zero Plain Text**: Complete removal of plain text credential storage

### 🔧 Technical Changes

#### Backend (budapp service)
- Added `encrypted_key` column to `credential` table
- Added `encrypted_credential` column to `cloud_credentials` table
- Updated models to use only encrypted fields
- Modified services to:
  - Encrypt credentials on creation
  - Decrypt only when absolutely necessary
  - Use hashed keys for efficient lookups
  - Handle Redis cache with encrypted keys

#### Frontend (budadmin)
- Fixed BudDrawer component to properly pass step properties
- Resolved issue where success messages weren't displaying on credential success pages

### 📁 Files Changed
- **Models**: `services/budapp/budapp/credential_ops/models.py`
- **Services**: `services/budapp/budapp/credential_ops/services.py`
- **Schemas**: `services/budapp/budapp/credential_ops/schemas.py`
- **Migrations**: 
  - `c438aff47613`: Adds encrypted columns (backward compatible)
  - `65c3cfbe96c9`: Removes plain text columns (final migration)
- **Frontend**: `services/budadmin/src/components/ui/bud/drawer/BudDrawer.tsx`

### 🚀 Migration Process

1. **Deploy Phase 1**: Deploy code with backward compatibility
   ```bash
   alembic -c ./budapp/alembic.ini upgrade head
   ```

2. **Encrypt Existing Data**: Run the encryption script
   ```bash
   python scripts/encrypt_existing_credentials.py
   ```

3. **Deploy Phase 2**: Apply final migration to remove plain columns
   ```bash
   alembic -c ./budapp/alembic.ini upgrade head
   ```

### ✅ Testing
- [x] Credential creation with encryption
- [x] Credential retrieval with decryption
- [x] API key validation using hashed keys
- [x] Redis cache operations
- [x] Cloud credential operations
- [x] Frontend success message display

### 🎯 Security Benefits
- **Database Breach Protection**: Even if database is compromised, credentials remain encrypted
- **Audit Compliance**: Meets encryption-at-rest requirements
- **Performance**: Hashed keys allow fast lookups without decryption overhead
- **Minimal Exposure**: Keys only decrypted when absolutely necessary

### ⚠️ Important Notes
- This is a **breaking change** requiring database migration
- Ensure RSA keys are properly configured before deployment
- Back up database before running migrations
- Test thoroughly in staging environment first

### 📚 Documentation
Migration guide available at: `services/budapp/docs/CREDENTIAL_ENCRYPTION_MIGRATION.md`

---
**Security is our top priority. This PR ensures all API keys and credentials are properly encrypted at rest.**