### PR TITLE
fix(budproxy): correct RSA private key path in Helm template

### DIFF
--- a/infra/helm/bud/templates/budproxy.yaml
+++ b/infra/helm/bud/templates/budproxy.yaml
@@ -62,7 +62,7 @@ spec:
             - name: TENSORZERO_CLICKHOUSE_URL
               value: "http://{{ .Values.clickhouse.auth.username }}:{{ .Values.clickhouse.auth.password }}@{{ .Release.Name }}-clickhouse:8123/budproxy"
             - name: TENSORZERO_RSA_PRIVATE_KEY_PATH
-              value: /app/keys/private-key.pem
+              value: /app/keys/rsa-private-key.pem
             - name: TENSORZERO_RSA_PRIVATE_KEY_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Fixed incorrect RSA private key path in budproxy Helm template
- Changed from `private-key.pem` to `rsa-private-key.pem` to match standard naming convention

## Test plan
- [ ] Verify Helm template renders correctly with `helm template`
- [ ] Ensure budproxy service starts successfully with the corrected key path
- [ ] Confirm RSA key operations work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)