### PR TITLE
Fix Helm templates for Dapr scopes and budplayground URL

### DIFF
--- a/infra/helm/bud/templates/dapr/pubsub.yaml
+++ b/infra/helm/bud/templates/dapr/pubsub.yaml
@@ -35,7 +35,7 @@ spec:
     maxMessagesCount: 1
     maxAwaitDurationMs: 50
 scopes:
-  - budmetrics
+  - {{ .Release.Name }}-budmetrics
 ---
 apiVersion: dapr.io/v2alpha1
 kind: Subscription
@@ -51,7 +51,7 @@ spec:
   pubsubname: {{ .Release.Name }}-pubsub
   deadLetterTopic: poisonMessages
 scopes:
-  - budapp
+  - {{ .Release.Name }}-budapp
 ---
 apiVersion: dapr.io/v2alpha1
 kind: Subscription
@@ -64,7 +64,7 @@ spec:
   pubsubname: {{ .Release.Name }}-pubsub
   deadLetterTopic: poisonMessages
 scopes:
-  - budsim
+  - {{ .Release.Name }}-budsim
 ---
 apiVersion: dapr.io/v2alpha1
 kind: Subscription
@@ -77,7 +77,7 @@ spec:
   pubsubname: {{ .Release.Name }}-pubsub
   deadLetterTopic: poisonMessages
 scopes:
-  - budcluster
+  - {{ .Release.Name }}-budcluster
 ---
 apiVersion: dapr.io/v2alpha1
 kind: Subscription
@@ -90,7 +90,7 @@ spec:
   pubsubname: {{ .Release.Name }}-pubsub
   deadLetterTopic: poisonMessages
 scopes:
-  - budmodel
+  - {{ .Release.Name }}-budmodel
 ---
 apiVersion: dapr.io/v2alpha1
 kind: Subscription
@@ -103,7 +103,7 @@ spec:
   pubsubname: {{ .Release.Name }}-pubsub
   deadLetterTopic: poisonMessages
 scopes:
-  - askbud
+  - {{ .Release.Name }}-askbud
 ---
 apiVersion: dapr.io/v2alpha1
 kind: Subscription
@@ -116,4 +116,4 @@ spec:
   pubsubname: {{ .Release.Name }}-pubsub
   deadLetterTopic: poisonMessages
 scopes:
-  - budeval
+  - {{ .Release.Name }}-budeval

--- a/infra/helm/bud/templates/microservices/budplayground.yaml
+++ b/infra/helm/bud/templates/microservices/budplayground.yaml
@@ -30,7 +30,7 @@ spec:
           - name: NEXT_PUBLIC_TEMP_API_BASE_URL
             value: {{ include "bud.ingress.url.budapp" $ }}
           - name: NEXT_PUBLIC_COPY_CODE_API_BASE_URL
-            value: {{ include "bud.ingress.url.budgateway" $ }}
+            value: {{ include "bud.ingress.url.budgateway" $ }}/v1/
         {{ $root := . }}
         {{- range $key, $value := .Values.microservices.budplayground.env }}
           - name: {{ $key }}


### PR DESCRIPTION
## Summary
- Fixed Dapr subscription scopes to include release name prefix for proper multi-release deployments
- Added /v1/ suffix to budgateway URL in budplayground configuration

## Changes
1. **Dapr PubSub Configuration** (`infra/helm/bud/templates/dapr/pubsub.yaml`):
   - Updated all subscription scopes to use `{{ .Release.Name }}-<service>` pattern
   - Ensures proper isolation between different Helm releases
   - Affected services: budmetrics, budapp, budsim, budcluster, budmodel, askbud, budeval

2. **Budplayground Configuration** (`infra/helm/bud/templates/microservices/budplayground.yaml`):
   - Added `/v1/` suffix to `NEXT_PUBLIC_COPY_CODE_API_BASE_URL` 
   - Ensures correct API endpoint routing for budgateway

## Test Plan
- [ ] Deploy Helm chart and verify Dapr subscriptions are created with correct scopes
- [ ] Verify budplayground can successfully communicate with budgateway API
- [ ] Test multi-release deployments to ensure proper scope isolation

🤖 Generated with [Claude Code](https://claude.ai/code)