### PR TITLE
Fix budgateway URL in budplayground configuration

### DIFF
--- a/infra/helm/bud/templates/microservices/budplayground.yaml
+++ b/infra/helm/bud/templates/microservices/budplayground.yaml
@@ -30,7 +30,7 @@ spec:
           - name: NEXT_PUBLIC_TEMP_API_BASE_URL
             value: {{ include "bud.ingress.url.budapp" $ }}
           - name: NEXT_PUBLIC_COPY_CODE_API_BASE_URL
-            value: {{ include "bud.ingress.url.budgateway" $ }}
+            value: {{ include "bud.ingress.url.budgateway" $ }}/v1/
         {{ $root := . }}
         {{- range $key, $value := .Values.microservices.budplayground.env }}
           - name: {{ $key }}


### PR DESCRIPTION
## Summary
- Added `/v1/` suffix to budgateway URL in budplayground Helm template configuration

## Changes
**Budplayground Configuration** (`infra/helm/bud/templates/microservices/budplayground.yaml`):
- Updated `NEXT_PUBLIC_COPY_CODE_API_BASE_URL` to include `/v1/` path suffix
- This ensures correct API endpoint routing when budplayground communicates with the budgateway service

## Test Plan
- [ ] Deploy Helm chart and verify budplayground configuration
- [ ] Test budplayground can successfully communicate with budgateway API at `/v1/` endpoints
- [ ] Verify code copying functionality works correctly with the updated URL

🤖 Generated with [Claude Code](https://claude.ai/code)