### PR TITLE
feat: refactor publish/unpublish functionality with improved UX

### DIFF
--- a/services/budadmin/src/flows/components/CustomSelect.tsx
+++ b/services/budadmin/src/flows/components/CustomSelect.tsx
@@ -9,7 +9,7 @@ export interface BudInputProps {
   onBlur?: () => void;
   onChange?: (value: string) => void;
   name: string;
-  label: string;
+  label?: string;
   info?: string;
   value?: string;
   placeholder?: string;
@@ -26,8 +26,9 @@ export interface BudInputProps {
 function CustomSelect(props: BudInputProps) {
   return (
     <div
-        className={`rounded-[6px] relative !bg-[transparent] !w-[100%] mb-[0] hover:bg-[#FFFFFF08] ${props.ClassNames}`}
-      >
+      className={`rounded-[6px] relative !bg-[transparent] !w-[100%] mb-[0] hover:bg-[#FFFFFF08] ${props.ClassNames}`}
+    >
+      {props.label && (
         <div className="w-full">
           <Text_12_400_EEEEEE className={`absolute px-[.2rem] -top-1.5 left-[1.1rem] tracking-[.035rem] z-10 flex items-center gap-1 text-nowrap floatingLabel`}>
             {props.label}
@@ -41,43 +42,44 @@ function CustomSelect(props: BudInputProps) {
             </CustomPopover>
           </Text_12_400_EEEEEE>
         </div>
-        <div className="custom-select-two w-full rounded-[6px] relative">
-          <ConfigProvider
-            theme={{
-              token: {
-                colorTextPlaceholder: '#808080',
-              },
+      )}
+      <div className="custom-select-two w-full rounded-[6px] relative">
+        <ConfigProvider
+          theme={{
+            token: {
+              colorTextPlaceholder: '#808080',
+            },
+          }}
+        >
+          <Select
+            placeholder={props.placeholder}
+            style={{
+              backgroundColor: "transparent",
+              color: "#EEEEEE",
+              border: "0.5px solid #757575",
+              width: "100%",
+              paddingTop: '.6rem',
+              paddingBottom: '.6rem',
+              fontSize: '.75rem'
             }}
-          >
-            <Select
-              placeholder={props.placeholder}
-              style={{
-                backgroundColor: "transparent",
-                color: "#EEEEEE",
-                border: "0.5px solid #757575",
-                width: "100%",
-                paddingTop: '.6rem',
-                paddingBottom: '.6rem',
-                fontSize: '.75rem'
-              }}
-              value={props.value || null}
-              size="large"
-              className={`drawerInp !bg-[transparent] text-[#EEEEEE] font-[300] shadow-none w-full indent-[.4rem] border-0 outline-0 hover:border-[#EEEEEE] focus:border-[#EEEEEE] active:border-[#EEEEEE] ${props.InputClasses}`}
-              options={props.selectOptions}
-              onChange={(value) => {
-                props.onChange(value)
-              }}
-              suffixIcon={
-                <img
-                  src={`/icons/customArrow.png`}
-                  alt="custom arrow"
-                  style={{ width: '10px', height: '7px' }}
-                />
-              }
-            />
-          </ConfigProvider>
-        </div>
+            value={props.value || null}
+            size="large"
+            className={`drawerInp !bg-[transparent] text-[#EEEEEE] font-[300] shadow-none w-full indent-[.4rem] border-0 outline-0 hover:border-[#EEEEEE] focus:border-[#EEEEEE] active:border-[#EEEEEE] ${props.InputClasses}`}
+            options={props.selectOptions}
+            onChange={(value) => {
+              props.onChange(value)
+            }}
+            suffixIcon={
+              <img
+                src={`/icons/customArrow.png`}
+                alt="custom arrow"
+                style={{ width: '10px', height: '7px' }}
+              />
+            }
+          />
+        </ConfigProvider>
       </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
- Moved publish action to dedicated Save button with pricing validation
- Changed main submit button to handle unpublish operations
- Converted price per token input to select dropdown with predefined options (1K-10M)
- Added separate loading states for publish and unpublish actions
- Fixed endpoint list refresh after publish/unpublish operations
- Made CustomSelect label prop optional for flexible usage

🤖 Generated with [Claude Code](https://claude.ai/code)