### PR TITLE
fix: resolve ProjectNameInput text entry issue across all forms

### DIFF
--- a/services/budadmin/src/components/ui/bud/dataEntry/BudForm.tsx
+++ b/services/budadmin/src/components/ui/bud/dataEntry/BudForm.tsx
@@ -75,24 +75,12 @@ export function BudForm(props: BudFormProps) {
   const { form, isExpandedView } = useContext(BudFormContext);
 
   useEffect(() => {
-    // Only set form values if we have actual data (not empty object)
+    // Only set form values on initial mount
     if (props.data && Object.keys(props.data).length > 0) {
-      // Get current form values
-      const currentValues = form.getFieldsValue();
-
-      // Check if values are actually different
-      const hasChanges = Object.keys(props.data).some(key => {
-        // Using JSON.stringify for a simple deep comparison. This is safer than reference equality for objects/arrays.
-        // For complex cases, a library like `lodash.isEqual` would be more robust.
-        return JSON.stringify(props.data[key]) !== JSON.stringify(currentValues[key]);
-      });
-
-      // Only update if there are actual changes
-      if (hasChanges) {
-        form.setFieldsValue(props.data);
-      }
+      form.setFieldsValue(props.data);
     }
-  }, [props.data, form]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Empty dependency array - only run once on mount
 
   // Don't reset fields on unmount - we want to preserve form data when navigating
   // The form will be properly initialized with data prop when remounting

--- a/services/budadmin/src/components/ui/bud/dataEntry/ProjectNameInput.tsx
+++ b/services/budadmin/src/components/ui/bud/dataEntry/ProjectNameInput.tsx
@@ -1,6 +1,6 @@
 import { Button, Form, Image, Input, Popover } from "antd";
 import EmojiPicker, { Categories, EmojiStyle, Theme } from "emoji-picker-react";
-import React, { use, useContext, useEffect } from "react";
+import React, { useContext, useEffect } from "react";
 import { BudFormContext } from "../context/BudFormContext";
 import { pxToRem, Text_26_600_FFFFFF } from "../../text";
 import { assetBaseUrl } from "@/components/environment";
@@ -11,7 +11,6 @@ import IconRender from "src/flows/components/BudIconRender";
 interface Props {
   placeholder: string;
   onChangeIcon?: (value: string) => void;
-  onChangeName?: (value: string) => void;
   isEdit?: boolean;
 }
 
@@ -105,9 +104,8 @@ export function ModelNameInput({
 
   useEffect(() => {
     onChange && onChange(name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [icon, name]);
-  const imageUrl = assetBaseUrl + icon;
-
   return (
     <div className="drawerNameInput flex flex-row items-start justify-between mb-[1rem]">
 
@@ -152,7 +150,7 @@ export function ModelNameInput({
         ]}
       >
         <Input
-          className="pl-2 rounded-[6px] !bg-transparent text-[#EEEEEE] placeholder-[#808080] !border-none outline-0 text-xl rw-full border-transparent focus:border-transparent focus:ring-0"
+          className="pl-2 rounded-[6px] !bg-transparent text-[#EEEEEE] placeholder-[#808080] !border-none outline-0 text-xl w-full border-transparent focus:border-transparent focus:ring-0"
           style={{ outline: 'none', border: 'none' }}
           type="text"
           placeholder={placeholder}
@@ -271,7 +269,7 @@ export function NameIconInput({
         ]}
       >
         <Input
-          className="pl-2 rounded-[6px] !bg-transparent text-[#EEEEEE] placeholder-[#808080] !border-none outline-0 text-xl rw-full border-transparent focus:border-transparent focus:ring-0"
+          className="pl-2 rounded-[6px] !bg-transparent text-[#EEEEEE] placeholder-[#808080] !border-none outline-0 text-xl w-full border-transparent focus:border-transparent focus:ring-0"
           style={{ outline: 'none', border: 'none' }}
           type="text"
           placeholder={placeholder}
@@ -285,17 +283,10 @@ export function NameIconInput({
 export default function ProjectNameInput({
   placeholder,
   onChangeIcon,
-  onChangeName,
   isEdit
 }: Props) {
   const { form } = useContext(BudFormContext);
   const icon = form.getFieldValue("icon");
-  const name = form.getFieldValue("name");
-
-  useEffect(() => {
-    onChangeIcon && onChangeIcon(icon);
-    onChangeName && onChangeName(name);
-  }, [icon, name]);
 
   return (
     <NameIconInput
@@ -303,6 +294,7 @@ export default function ProjectNameInput({
       icon={icon}
       onChangeIcon={(emoji) => {
         form.setFieldsValue({ icon: emoji });
+        onChangeIcon && onChangeIcon(emoji);
       }}
       disabled={false}
       isEdit={isEdit}

--- a/services/budadmin/src/flows/Cluster/AddCluster.tsx
+++ b/services/budadmin/src/flows/Cluster/AddCluster.tsx
@@ -76,16 +76,6 @@ export default function AddCluster() {
             <div className="pt-[.87rem]">
               <ProjectNameInput
                 placeholder="Enter Cluster Name"
-                onChangeName={(name) => {
-                  if (name !== clusterValues.name) {
-                    setClusterValues({ ...clusterValues, name });
-                  }
-                }}
-                onChangeIcon={(icon) => {
-                  if (icon !== clusterValues.icon) {
-                    setClusterValues({ ...clusterValues, icon });
-                  }
-                }}
                 isEdit={true}
               />
 

--- a/services/budadmin/src/flows/Cluster/EditCluster.tsx
+++ b/services/budadmin/src/flows/Cluster/EditCluster.tsx
@@ -25,8 +25,6 @@ function EditClusterForm() {
       <DrawerCard classNames="pb-0">
         <ProjectNameInput
           placeholder="Enter Cluster Name"
-          onChangeName={(name) => form.setFieldsValue({ name })}
-          onChangeIcon={(icon) => form.setFieldsValue({ icon })}
           isEdit={true}
         />
         <div

--- a/services/budadmin/src/flows/Cluster/_cloud/ConfigureClusterDetails.tsx
+++ b/services/budadmin/src/flows/Cluster/_cloud/ConfigureClusterDetails.tsx
@@ -98,12 +98,6 @@ export default function ConfigureClusterDetails() {
             <div className="pt-[.87rem]">
               <ProjectNameInput
                 placeholder="Enter Cluster Name"
-                onChangeName={(name) =>
-                  setClusterValues({ ...clusterValues, name })
-                }
-                onChangeIcon={(icon) =>
-                  setClusterValues({ ...clusterValues, icon })
-                }
                 isEdit={true}
               />
 

--- a/services/budadmin/src/flows/NewProject.tsx
+++ b/services/budadmin/src/flows/NewProject.tsx
@@ -75,8 +75,6 @@ export default function NewProject() {
           <DrawerCard classNames="pb-0">
             <ProjectNameInput
               placeholder="Enter Project Name"
-              onChangeName={(name) => form.setFieldsValue({ name })}
-              onChangeIcon={(icon) => form.setFieldsValue({ icon })}
               isEdit={true}
             />
             <div className="flex justify-start items-center px-[.65rem] mb-[1.65rem]">

--- a/services/budadmin/src/flows/Project/EditProject.tsx
+++ b/services/budadmin/src/flows/Project/EditProject.tsx
@@ -48,14 +48,6 @@ function EditProjectForm() {
       <DrawerCard classNames="pb-0">
         <ProjectNameInput
           placeholder="Enter Project Name"
-          onChangeIcon={(icon) => setProjectValues({
-            ...projectValues,
-            icon: icon
-          })}
-          onChangeName={(name) => setProjectValues({
-            ...projectValues,
-            name: name
-          })}
         />
         <div className="mt-[.5rem]">
           <div>

--- a/services/budadmin/src/flows/settings/EditProfile.tsx
+++ b/services/budadmin/src/flows/settings/EditProfile.tsx
@@ -58,8 +58,6 @@ export default function EditProfile() {
           <DrawerCard classNames="pb-0">
             <ProjectNameInput
               placeholder="Enter Name"
-              onChangeName={(name) => form.setFieldsValue({ name })}
-              onChangeIcon={(icon) => form.setFieldsValue({ icon })}
               isEdit={true}
             />
             <div className="mt-[1.5rem] w-[full%] flex flex-col gap-[1.3rem]">


### PR DESCRIPTION
- Remove conflicting form value callbacks from all components using ProjectNameInput
- Fix BudForm to only initialize values on mount, not on every render
- Fix CSS typo from 'rw-full' to 'w-full' for proper width styling
- Clean up unused imports and onChangeName prop in ProjectNameInput component
- Update all usages in NewProject, EditProject, AddCluster, EditCluster, ConfigureClusterDetails, and EditProfile
- Add ESLint disable comments for intentional dependency exclusions

The issue was caused by manual form.setFieldsValue() calls conflicting with Ant Design Form's automatic field management, and form values being reset on every render.

🤖 Generated with [Claude Code](https://claude.ai/code)