### PR TITLE
fix(budeval): use dynamic namespace detection instead of hardcoded values

### DIFF
--- a/services/budeval/.gitignore
+++ b/services/budeval/.gitignore
@@ -60,3 +60,5 @@ Debug/
 
 # Screts
 secrets.json
+app.yaml
+k3s.yaml

--- a/services/budeval/budeval/core/schemas.py
+++ b/services/budeval/budeval/core/schemas.py
@@ -6,6 +6,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from budeval.commons.storage_config import StorageConfig
+
 
 class EvaluationEngine(str, Enum):
     """Supported evaluation engines."""
@@ -98,7 +100,7 @@ class GenericEvaluationRequest(BaseModel):
 
     # Infrastructure configuration
     kubeconfig: str | None = Field(None, description="Kubernetes configuration")
-    namespace: str = Field("budeval", description="Kubernetes namespace")
+    namespace: str = Field(default_factory=StorageConfig.get_current_namespace, description="Kubernetes namespace")
 
     # Additional parameters
     debug: bool = Field(False, description="Enable debug mode")

--- a/services/budeval/budeval/evals/workflows.py
+++ b/services/budeval/budeval/evals/workflows.py
@@ -103,7 +103,6 @@ class EvaluationWorkflow:
                 num_workers=1,
                 timeout_minutes=30,
                 kubeconfig=evaluate_model_request_json.kubeconfig,
-                namespace="budeval",
                 debug=True,
             )
 
@@ -114,9 +113,11 @@ class EvaluationWorkflow:
             transformed = transformer.transform_request(generic_request)
 
             # Create ConfigMap with transformed configuration
+            from budeval.commons.storage_config import StorageConfig
+
             from .configmap_manager import ConfigMapManager
 
-            configmap_manager = ConfigMapManager(namespace="budeval")
+            configmap_manager = ConfigMapManager(namespace=StorageConfig.get_current_namespace())
 
             configmap_result = configmap_manager.create_generic_config_map(
                 eval_request_id=str(generic_request.eval_request_id),

--- a/services/budeval/budeval/shared/job_schema.py
+++ b/services/budeval/budeval/shared/job_schema.py
@@ -2,12 +2,14 @@ from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from budeval.commons.storage_config import StorageConfig
+
 
 class Job(BaseModel):
     # General info
     uuid: str
     runner_type: Literal["kubernetes", "docker"] = Field(..., description="Which runner type to use")
-    namespace: str = Field(default="budeval")
+    namespace: str = Field(default_factory=StorageConfig.get_current_namespace)
 
     # Engine config
     docker_image: str = Field(..., description="Docker image used to run the engine")


### PR DESCRIPTION
## Summary
- Fixed ConfigMap creation failures due to cross-namespace permission errors
- Replaced hardcoded "budeval" namespace with dynamic namespace detection
- Service now works correctly in any Kubernetes namespace (bud-dev, production, etc.)

## Problem
The budeval service was failing to create ConfigMaps with the error:
```
configmaps is forbidden: User "system:serviceaccount:bud-dev:default" cannot create resource "configmaps" in API group "" in the namespace "budeval"
```

This occurred because the service running in the `bud-dev` namespace was trying to create ConfigMaps in the hardcoded `budeval` namespace, causing cross-namespace permission issues.

## Solution
Updated the following components to use dynamic namespace detection via `StorageConfig.get_current_namespace()`:
- **workflows.py**: ConfigMapManager instantiation now uses the current namespace
- **core/schemas.py**: GenericEvaluationRequest schema uses default_factory for namespace field
- **shared/job_schema.py**: Job schema uses default_factory for namespace field

The namespace is now automatically detected from:
1. `NAMESPACE` environment variable (if set)
2. `/var/run/secrets/kubernetes.io/serviceaccount/namespace` (when running in Kubernetes)
3. Falls back to "default" if neither is available

## Test Plan
- [x] Verified imports work without circular dependencies
- [x] Tested namespace detection returns correct value from environment
- [x] Confirmed Job and GenericEvaluationRequest schemas use dynamic namespace
- [ ] Deploy to dev environment and verify ConfigMap creation works
- [ ] Test in production environment