### PR TITLE
feat(infra/budproxy): enable blocking and geoip analytics

### DIFF
--- a/infra/helm/bud/templates/budproxy.yaml
+++ b/infra/helm/bud/templates/budproxy.yaml
@@ -10,8 +10,12 @@ data:
     [gateway.rate_limits]
     enabled = true
 
+    [gateway.blocking]
+    enabled = true
+
     [gateway.analytics]
     enabled = true
+    geoip_db_path = "/app/geo/GeoLite2-City.mmdb"
 
     [gateway.observability.kafka]
     enabled = true


### PR DESCRIPTION
## Summary
- Enabled gateway blocking functionality for improved security
- Configured GeoIP database path for enhanced analytics capabilities
- Updated budproxy Helm template configuration

## Changes Made
- Added `[gateway.blocking]` section with `enabled = true`
- Added `geoip_db_path` configuration to analytics section pointing to `/app/geo/GeoLite2-City.mmdb`

## Test Plan
- [ ] Deploy to development environment
- [ ] Verify blocking functionality is active
- [ ] Confirm GeoIP analytics are working with the configured database path
- [ ] Check proxy logs for any configuration errors

🤖 Generated with [Claude Code](https://claude.ai/code)