### PR TITLE
fix(playground): add fallback for clipboard copy when API is blocked

### DIFF
--- a/services/budplayground/app/components/bud/components/display/CopyText.tsx
+++ b/services/budplayground/app/components/bud/components/display/CopyText.tsx
@@ -5,9 +5,30 @@ export function CopyText(props: { text: string }) {
 
     const [copied, setCopied] = useState(false);
 
-    const handleCopy = () => {
-        navigator.clipboard.writeText(props.text);
-        setCopied(true);
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(props.text);
+            setCopied(true);
+        } catch (err) {
+            // Fallback for when Clipboard API is blocked
+            const textArea = document.createElement("textarea");
+            textArea.value = props.text;
+            textArea.style.position = "fixed";
+            textArea.style.left = "-999999px";
+            textArea.style.top = "-999999px";
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+            try {
+                // @ts-ignore - Using deprecated API as fallback when Clipboard API is blocked
+                document.execCommand('copy');
+                setCopied(true);
+            } catch (fallbackErr) {
+                console.error('Failed to copy:', fallbackErr);
+            } finally {
+                textArea.remove();
+            }
+        }
     }
 
     useEffect(() => {


### PR DESCRIPTION
- Add try-catch wrapper around navigator.clipboard.writeText
- Implement document.execCommand fallback for restricted environments
- Handle permissions policy violations in iframes
- Improve error handling for clipboard operations

🤖 Generated with [Claude Code](https://claude.ai/code)