### PR TITLE
fix(budmodel): update XPath selector for HuggingFace model images

### DIFF
--- a/services/budmodel/budmodel/model_info/huggingface.py
+++ b/services/budmodel/budmodel/model_info/huggingface.py
@@ -899,7 +899,7 @@ class HuggingfaceUtils:
             # Parse the HTML content
             tree = lxml_html.fromstring(response.content)
             # Try to get the image using the XPath
-            xpath_selector = "/html/body/div/main/header/div/div[1]/div[1]/img"
+            xpath_selector = "/html/body/div/main/header/div/div[1]/div[1]/a/img"
             img_elements = tree.xpath(xpath_selector)
             # If XPath didn't work, try the CSS selector
             if not img_elements:


### PR DESCRIPTION
## Summary
- Fixed XPath selector in HuggingFaceUtils to correctly locate model images
- Added anchor tag (`/a`) to the image path selector to match current HuggingFace HTML structure

## Changes
- Updated XPath from `/html/body/div/main/header/div/div[1]/div[1]/img` to `/html/body/div/main/header/div/div[1]/div[1]/a/img`

## Test plan
- [ ] Test model image extraction on various HuggingFace model pages
- [ ] Verify fallback to CSS selector still works when XPath doesn't match
- [ ] Confirm no regression in model info extraction functionality

🤖 Generated with [Claude Code](https://claude.ai/code)