### PR TITLE
fix(budsim): ensure case-insensitive device type comparison

### DIFF
--- a/services/budsim/budsim/engine_ops/utils.py
+++ b/services/budsim/budsim/engine_ops/utils.py
@@ -48,7 +48,7 @@ def fetch_compatible_engines(
             compatible_engines.append(
                 {
                     "engine_name": engine["engine"],
-                    "device": engine["device_architecture"],
+                    "device": engine["device_architecture"].lower(),
                     "image": engine["container_image"],
                 }
             )

--- a/services/budsim/budsim/simulator/services.py
+++ b/services/budsim/budsim/simulator/services.py
@@ -1072,7 +1072,7 @@ class SimulationService:
                 # Run evolution once per device type with full cluster context
                 for device_type, device_group in device_groups.items():
                     for engine_device_combo in compatible_engines:
-                        if engine_device_combo["device"] == device_type:
+                        if engine_device_combo["device"].lower() == device_type.lower():
                             logger.debug(
                                 f"Processing engine-device combination: Engine={engine_device_combo['engine_name']}, "
                                 f"Device={device_type}"

--- a/services/budsim/budsim/simulator/workflows.py
+++ b/services/budsim/budsim/simulator/workflows.py
@@ -154,7 +154,7 @@ class SimulationWorkflows:
                             )
 
                         for engine_device_combo in compatible_engines:
-                            if device_type == engine_device_combo["device"]:
+                            if device_type.lower() == engine_device_combo["device"].lower():
                                 devices_found += 1
                                 # Prepare device config with proper memory conversion
                                 device_config = deepcopy(device)


### PR DESCRIPTION
## Summary
- Fixed device type comparison logic to be case-insensitive across budsim service
- Normalized device architecture strings to lowercase to ensure consistent matching
- Prevents potential mismatches when device types have different case variations

## Changes
- Modified `fetch_compatible_engines()` in `engine_ops/utils.py` to return lowercase device types
- Updated device comparison logic in `simulator/services.py` to use case-insensitive comparison
- Updated device comparison logic in `simulator/workflows.py` to use case-insensitive comparison

## Test Plan
- [x] Verify device matching works with mixed case device types (e.g., "CUDA" vs "cuda")
- [x] Ensure simulation workflows correctly identify compatible engines regardless of case
- [x] Test with various device architectures to confirm consistent behavior

🤖 Generated with [Claude Code](https://claude.ai/code)