### PR TITLE
feat(ask-bud): configure ask-bud service with database and inference settings

### DIFF
--- a/infra/helm/bud/values.ditto.yaml
+++ b/infra/helm/bud/values.ditto.yaml
@@ -4,3 +4,24 @@ ingress:
 
 # disable keel
 deploymentAnnotations: null
+
+# imagePullPolicy: IfNotPresent
+
+microservices:
+    budmodel:
+        storageSize: "1Ti"
+    buddoc:
+        image: dittops/buddoc:nightly
+    budapp:
+        image: dittops/budapp:nightly
+    budgateway:
+        image: dittops/budgateway:nightly
+    budsim:
+        image: dittops/budsim:nightly
+    budcluster:
+        image: dittops/budcluster:nightly
+    askbud:
+        image: dittops/ask-bud:nightly
+    global:
+        env:
+            LOG_LEVEL: DEBUG

--- a/infra/helm/bud/values.yaml
+++ b/infra/helm/bud/values.yaml
@@ -41,7 +41,15 @@ microservices:
         image: budstudio/askbud:nightly
         daprid: askbud
         env:
+            PSQL_HOST: "{{ $.Release.Name }}-postgresql"
+            PSQL_PORT: "5432"
+            PSQL_USER: budask
+            PSQL_PASSWORD: budask
+            PSQL_DB_NAME: budask
             INFERENCE_MODEL: qwen3-32b
+            INFERENCE_API_KEY: "test"
+            BUD_CLUSTER_APP_ID: budcluster
+            BUD_APP_ID: budapp
     budapp:
         image: budstudio/budapp:nightly
         daprid: budapp

--- a/services/ask-bud/requirements.txt
+++ b/services/ask-bud/requirements.txt
@@ -21,4 +21,4 @@ alembic>=1.13.3
 alembic-postgresql-enum>=1.3.0
 
 # Agent
-openai-agents
+openai-agents==0.0.16


### PR DESCRIPTION
## Summary
- Configure ask-bud service with PostgreSQL database connection settings
- Pin openai-agents dependency to version 0.0.16 for stability
- Add Ditto environment configuration with nightly images and debug logging

## Changes Made
1. **Helm Values Configuration (`infra/helm/bud/values.yaml`)**:
   - Added PostgreSQL connection parameters for ask-bud service
   - Configured inference model and API key settings
   - Added references to budcluster and budapp service IDs

2. **Ditto Environment (`infra/helm/bud/values.ditto.yaml`)**:
   - Configured all microservices to use nightly Docker images
   - Set global debug logging level
   - Added 1Ti storage size for budmodel service

3. **Dependencies (`services/ask-bud/requirements.txt`)**:
   - Pinned openai-agents to version 0.0.16 to ensure stability

## Test Plan
- [ ] Verify ask-bud service starts successfully with new database configuration
- [ ] Confirm inference model connectivity with provided API key
- [ ] Test inter-service communication with budcluster and budapp
- [ ] Validate debug logging is working in Ditto environment

🤖 Generated with [Claude Code](https://claude.ai/code)