### PR TITLE
fix: resolve quantization flow infinite loop and navigation issues

### DIFF
--- a/services/budadmin/src/flows/Quantization/QuantizationDetail.tsx
+++ b/services/budadmin/src/flows/Quantization/QuantizationDetail.tsx
@@ -11,7 +11,7 @@ import { Text_12_300_EEEEEE, Text_12_400_FFFFFF } from "@/components/ui/text";
 import CustomPopover from "../components/customPopover";
 import { ConfigProvider, Select, Image } from "antd";
 import { useDeployModel } from "src/stores/useDeployModel";
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { BudFormContext } from "@/components/ui/bud/context/BudFormContext";
 import { useModels } from "src/hooks/useModels";
 
@@ -36,50 +36,58 @@ export default function QuantizationDetail() {
   ];
 
   const handleNext = async () => {
-    form.submit();
+    // form.submit();
+
+    // Use the form values or the initialized values
+    const workflowData = quantizationWorkflow || getInitialValues();
 
     const result = await createQuantizationWorkflow(
-      quantizationWorkflow.modelName,
-      quantizationWorkflow.type,
-      quantizationWorkflow.hardware,
+      workflowData.modelName,
+      workflowData.type,
+      workflowData.hardware,
     );
     if (!result) {
       return;
     }
-    // setQuantizationWorkflow(values);
     openDrawerWithStep("quantization-method");
   };
 
   const handleChange = (name: string, value: any) => {
     form.setFieldsValue({ [name]: value });
     form.validateFields([name]);
-    setQuantizationWorkflow({ ...quantizationWorkflow, [name]: value });
+
+    // Get current workflow or initialize with defaults
+    const currentWorkflow = quantizationWorkflow || getInitialValues();
+    setQuantizationWorkflow({ ...currentWorkflow, [name]: value });
   };
 
-  useEffect(() => {
-    let defaultValues = {
-      type: typeItems[0].value,
-      hardware: hardwareItems[0].value,
-      modelName: selectedModel?.name + "_INT8",
+  // Get initial values for the form - this ensures we have data on first render
+  const getInitialValues = () => {
+    // If quantizationWorkflow already has data, use it
+    if (quantizationWorkflow && quantizationWorkflow.modelName) {
+      return quantizationWorkflow;
+    }
+
+    // Otherwise, create default values
+    return {
+      type: quantizationWorkflow?.type || typeItems[0].value,
+      hardware: quantizationWorkflow?.hardware || hardwareItems[0].value,
+      modelName: quantizationWorkflow?.modelName || (selectedModel?.name ? `${selectedModel.name}_INT8` : ""),
+      method: quantizationWorkflow?.method || null,
+      weight: quantizationWorkflow?.weight || null,
+      activation: quantizationWorkflow?.activation || null,
+      clusterId: quantizationWorkflow?.clusterId || null
     };
-    if (quantizationWorkflow?.type) {
-      defaultValues.type = quantizationWorkflow?.type;
-    }
-    if (quantizationWorkflow?.hardware) {
-      defaultValues.hardware = quantizationWorkflow?.hardware;
-    }
-    if (quantizationWorkflow?.modelName) {
-      defaultValues.modelName = quantizationWorkflow?.modelName;
-    }
-    setQuantizationWorkflow({ ...quantizationWorkflow, ...defaultValues });
-  }, []);
+  };
+
+  const initialValues = getInitialValues();
 
   return (
     <BudForm
-      data={quantizationWorkflow}
+      data={initialValues}
       backText="Back"
       nextText="Next"
-      disableNext={!quantizationWorkflow?.modelName}
+      disableNext={!initialValues.modelName}
       onBack={() => {
         closeDrawer();
       }}

--- a/services/budadmin/src/flows/Quantization/QuantizationMethod.tsx
+++ b/services/budadmin/src/flows/Quantization/QuantizationMethod.tsx
@@ -82,8 +82,8 @@ export default function QuantizationMethod() {
     if (!result_advanced) {
       return;
     }
-    openDrawerWithStep("quantization-simulation-status");
-    // openDrawerWithStep("advanced-settings")
+    // openDrawerWithStep("quantization-simulation-status");
+    openDrawerWithStep("advanced-settings")
   };
 
   return (


### PR DESCRIPTION
## Summary
- Fixed infinite render loop causing browser hang when clicking "Next" in quantization flow
- Restored proper navigation flow through all quantization steps
- Fixed default values not showing up in form fields

## Problem
The quantization flow in budadmin had two critical issues:
1. **Infinite render loop**: Clicking "Next" on the first step caused the browser to hang
2. **Navigation issue**: Flow was skipping step 3 (Advanced Settings) and jumping directly from step 2 to step 4

## Root Cause Analysis
1. **Infinite loop**: The `useEffect` in QuantizationDetail was spreading `quantizationWorkflow` state with a stale closure, combined with BudForm only initializing on mount
2. **Navigation**: QuantizationMethod component was incorrectly navigating to "quantization-simulation-status" instead of "advanced-settings"

## Solution
1. **Fixed QuantizationDetail component**:
   - Removed problematic `useEffect` with stale closure
   - Added `getInitialValues()` function for proper form initialization
   - Ensured form gets properly initialized data on first render
   - Updated state management to prevent circular dependencies

2. **Fixed navigation flow**:
   - Restored navigation to "advanced-settings" (step 3) after method selection
   - Flow now correctly goes: Details → Method → Advanced → Simulation → Cluster → Running → Result

## Testing
- [x] Quantization flow loads without hanging
- [x] Default values appear correctly in form fields
- [x] Navigation proceeds through all steps in correct order
- [x] No infinite re-renders or performance issues
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)