### PR TITLE
feat: added error message for deployment used in prompt

### DIFF
--- a/services/budapp/requirements.txt
+++ b/services/budapp/requirements.txt
@@ -30,7 +30,7 @@ alembic-postgresql-enum>=1.3.0
 
 # Security
 passlib>=1.7.4
-bcrypt>=4.2.0
+bcrypt==4.1.3  # Pin to version compatible with passlib 1.7.4
 PyJWT>=2.10.1
 
 # Redis

--- a/services/budapp/tests/test_cloud_model_delete.py
+++ b/services/budapp/tests/test_cloud_model_delete.py
@@ -33,6 +33,7 @@ from budapp.model_ops.crud import ProviderDataManager
 from budapp.credential_ops.services import CredentialService
 from budapp.workflow_ops.services import WorkflowService
 from budapp.model_ops.models import Provider as ProviderModel
+from budapp.prompt_ops.crud import PromptVersionDataManager
 from budapp.shared.notification_service import BudNotifyService
 
 
@@ -89,6 +90,7 @@ async def test_delete_cloud_model_endpoint_immediate_deletion():
     mock_workflow_manager = AsyncMock(spec=WorkflowDataManager)
     mock_workflow_step_manager = AsyncMock(spec=WorkflowStepDataManager)
     mock_provider_manager = AsyncMock(spec=ProviderDataManager)
+    mock_prompt_version_manager = AsyncMock(spec=PromptVersionDataManager)
     mock_credential_service = AsyncMock(spec=CredentialService)
     mock_notify_service = AsyncMock(spec=BudNotifyService)
     mock_workflow_service = AsyncMock(spec=WorkflowService)
@@ -97,6 +99,7 @@ async def test_delete_cloud_model_endpoint_immediate_deletion():
     mock_endpoint_manager.retrieve_by_fields.return_value = mock_endpoint
     mock_endpoint_manager.update_by_fields.return_value = mock_endpoint
     mock_provider_manager.retrieve_by_fields.return_value = mock_provider
+    mock_prompt_version_manager.get_prompt_versions_by_endpoint_id.return_value = []  # No active prompts
     mock_workflow_service.retrieve_or_create_workflow.return_value = mock_workflow
     mock_credential_service.update_proxy_cache.return_value = None
     mock_notify_service.send_notification.return_value = None
@@ -116,6 +119,7 @@ async def test_delete_cloud_model_endpoint_immediate_deletion():
          patch('budapp.endpoint_ops.services.WorkflowDataManager', return_value=mock_workflow_manager), \
          patch('budapp.endpoint_ops.services.WorkflowStepDataManager', return_value=mock_workflow_step_manager), \
          patch('budapp.endpoint_ops.services.ProviderDataManager', return_value=mock_provider_manager), \
+         patch('budapp.endpoint_ops.services.PromptVersionDataManager', return_value=mock_prompt_version_manager), \
          patch('budapp.endpoint_ops.services.CredentialService', return_value=mock_credential_service), \
          patch('budapp.endpoint_ops.services.BudNotifyService', return_value=mock_notify_service), \
          patch('budapp.endpoint_ops.services.WorkflowService', return_value=mock_workflow_service):
@@ -223,6 +227,7 @@ async def test_delete_regular_model_endpoint_workflow_deletion():
     mock_workflow_manager = AsyncMock(spec=WorkflowDataManager)
     mock_workflow_step_manager = AsyncMock(spec=WorkflowStepDataManager)
     mock_provider_manager = AsyncMock(spec=ProviderDataManager)
+    mock_prompt_version_manager = AsyncMock(spec=PromptVersionDataManager)
     mock_credential_service = AsyncMock(spec=CredentialService)
     mock_workflow_service = AsyncMock(spec=WorkflowService)
 
@@ -230,6 +235,7 @@ async def test_delete_regular_model_endpoint_workflow_deletion():
     mock_endpoint_manager.retrieve_by_fields.return_value = mock_endpoint
     mock_endpoint_manager.update_by_fields.return_value = mock_endpoint
     mock_provider_manager.retrieve_by_fields.return_value = mock_provider
+    mock_prompt_version_manager.get_prompt_versions_by_endpoint_id.return_value = []  # No active prompts
     mock_workflow_service.retrieve_or_create_workflow.return_value = mock_workflow
     mock_credential_service.update_proxy_cache.return_value = None
     mock_workflow_step_manager.insert_one.return_value = None
@@ -248,6 +254,7 @@ async def test_delete_regular_model_endpoint_workflow_deletion():
          patch('budapp.endpoint_ops.services.WorkflowDataManager', return_value=mock_workflow_manager), \
          patch('budapp.endpoint_ops.services.WorkflowStepDataManager', return_value=mock_workflow_step_manager), \
          patch('budapp.endpoint_ops.services.ProviderDataManager', return_value=mock_provider_manager), \
+         patch('budapp.endpoint_ops.services.PromptVersionDataManager', return_value=mock_prompt_version_manager), \
          patch('budapp.endpoint_ops.services.CredentialService', return_value=mock_credential_service), \
          patch('budapp.endpoint_ops.services.WorkflowService', return_value=mock_workflow_service):
 
@@ -349,6 +356,7 @@ async def test_delete_cloud_model_endpoint_with_cluster_follows_workflow():
     mock_workflow_manager = AsyncMock(spec=WorkflowDataManager)
     mock_workflow_step_manager = AsyncMock(spec=WorkflowStepDataManager)
     mock_provider_manager = AsyncMock(spec=ProviderDataManager)
+    mock_prompt_version_manager = AsyncMock(spec=PromptVersionDataManager)
     mock_credential_service = AsyncMock(spec=CredentialService)
     mock_workflow_service = AsyncMock(spec=WorkflowService)
 
@@ -356,6 +364,7 @@ async def test_delete_cloud_model_endpoint_with_cluster_follows_workflow():
     mock_endpoint_manager.retrieve_by_fields.return_value = mock_endpoint
     mock_endpoint_manager.update_by_fields.return_value = mock_endpoint
     mock_provider_manager.retrieve_by_fields.return_value = mock_provider
+    mock_prompt_version_manager.get_prompt_versions_by_endpoint_id.return_value = []  # No active prompts
     mock_workflow_service.retrieve_or_create_workflow.return_value = mock_workflow
     mock_credential_service.update_proxy_cache.return_value = None
     mock_workflow_step_manager.insert_one.return_value = None
@@ -374,6 +383,7 @@ async def test_delete_cloud_model_endpoint_with_cluster_follows_workflow():
          patch('budapp.endpoint_ops.services.WorkflowDataManager', return_value=mock_workflow_manager), \
          patch('budapp.endpoint_ops.services.WorkflowStepDataManager', return_value=mock_workflow_step_manager), \
          patch('budapp.endpoint_ops.services.ProviderDataManager', return_value=mock_provider_manager), \
+         patch('budapp.endpoint_ops.services.PromptVersionDataManager', return_value=mock_prompt_version_manager), \
          patch('budapp.endpoint_ops.services.CredentialService', return_value=mock_credential_service), \
          patch('budapp.endpoint_ops.services.WorkflowService', return_value=mock_workflow_service):
 


### PR DESCRIPTION
Summary

  This PR adds validation to prevent deletion of deployments/endpoints that are being used by active prompts, ensuring data integrity and preventing orphaned prompt configurations.

Problem

  Previously, users could delete a deployment/endpoint without checking if any active prompts were using it. This would result in:
  - Broken prompt configurations that reference non-existent endpoints
  - Cascade deletion of prompt versions due to foreign key constraints
  - Poor user experience with no warning about affected prompts

Solution

  Added a validation check in the endpoint deletion flow that:
  1. Checks if any active prompt versions are using the endpoint before deletion
  2. Blocks the deletion with a clear error message if prompts are found
  3. Returns HTTP 400 (Bad Request) status with the name of the affected prompt

  Type of Change:
  - Bug fix (non-breaking change which fixes an issue)
  - New feature (non-breaking change which adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to not work as expected)
  
  
<img width="1385" height="517" alt="image" src="https://github.com/user-attachments/assets/cff4099f-6f09-4f0e-a2c4-a448fb8ae290" />