### PR TITLE
feat: playground list api modified with tool enabled query param support

### DIFF
--- a/services/budapp/budapp/endpoint_ops/crud.py
+++ b/services/budapp/budapp/endpoint_ops/crud.py
@@ -326,6 +326,7 @@ class EndpointDataManager(DataManagerUtils):
             "modality": filters.pop("modality", []),
             "model_size": filters.pop("model_size", None),
             "model_name": filters.pop("model_name", None),
+            "tool_enabled": filters.pop("tool_enabled", None),  # JSONB field filter
         }
 
         # Validate the remaining filters
@@ -354,6 +355,21 @@ class EndpointDataManager(DataManagerUtils):
             # Convert model size to a pre-defined range of numbers
             model_size_min, model_size_max = get_param_range(explicit_filters["model_size"])
             explicit_conditions.append(Model.model_size.between(model_size_min, model_size_max))
+
+        # Add tool_enabled filter condition if specified
+        if explicit_filters["tool_enabled"] is not None:
+            if explicit_filters["tool_enabled"]:
+                # Filter for endpoints where enable_tool_calling is true
+                explicit_conditions.append(EndpointModel.deployment_config["enable_tool_calling"].astext == "true")
+            else:
+                # Filter for endpoints where enable_tool_calling is false, null, or doesn't exist
+                explicit_conditions.append(
+                    or_(
+                        EndpointModel.deployment_config["enable_tool_calling"].astext == "false",
+                        EndpointModel.deployment_config["enable_tool_calling"].is_(None),
+                        EndpointModel.deployment_config.is_(None),
+                    )
+                )
 
         # Generate statements according to search or filters
         if search:

--- a/services/budapp/budapp/playground_ops/schemas.py
+++ b/services/budapp/budapp/playground_ops/schemas.py
@@ -63,6 +63,7 @@ class PlaygroundDeploymentFilter(BaseModel):
     status: EndpointStatusEnum | None = None
     model_name: str | None = None
     model_size: str | None = None
+    tool_enabled: bool | None = None
 
     @field_validator("model_size")
     def parse_model_size(cls, v: Optional[str]) -> Optional[int]:

--- a/services/budapp/requirements.txt
+++ b/services/budapp/requirements.txt
@@ -30,7 +30,7 @@ alembic-postgresql-enum>=1.3.0
 
 # Security
 passlib>=1.7.4
-bcrypt>=4.2.0
+bcrypt==4.1.3  # Pin to version compatible with passlib 1.7.4
 PyJWT>=2.10.1
 
 # Redis


### PR DESCRIPTION
This PR adds support for filtering endpoints by tool calling capability in the playground API. It allows users to filter deployment endpoints based on whether they have tool calling enabled or
  disabled.

  Changes

  Features

  - Tool-enabled filtering: Added tool_enabled boolean filter parameter to the playground deployment filters
    - When true: Filters for endpoints with enable_tool_calling: true in deployment_config
    - When false: Filters for endpoints with enable_tool_calling: false, null, or missing
    - When not specified: No filtering applied

  Bug Fixes

  - Bcrypt compatibility: Pinned bcrypt to version 4.1.3 to resolve compatibility issues with passlib 1.7.4

  Technical Details

  Modified Files

  1. services/budapp/budapp/endpoint_ops/crud.py
    - Enhanced get_endpoints_for_playground() method to handle tool_enabled filtering
    - Added JSONB field filtering logic for deployment_config["enable_tool_calling"]
    - Properly handles null/missing values when filtering for disabled tools
  2. services/budapp/budapp/playground_ops/schemas.py
    - Added tool_enabled: bool | None field to PlaygroundDeploymentFilter schema
  3. services/budapp/requirements.txt
    - Pinned bcrypt to 4.1.3 for compatibility

Screenshots
<img width="1099" height="721" alt="image" src="https://github.com/user-attachments/assets/e141d152-4035-4c88-bf51-d7bdff39c80a" />
<img width="1027" height="755" alt="image" src="https://github.com/user-attachments/assets/30522ad6-fbcd-40be-923a-540917afcf6e" />