### PR TITLE
style(budadmin): enhance evaluation UI padding and rename tab

### DIFF
--- a/services/budadmin/src/components/evaluations/CurrentMetricsTable.tsx
+++ b/services/budadmin/src/components/evaluations/CurrentMetricsTable.tsx
@@ -85,7 +85,7 @@ const CurrentMetricsTable: React.FC<CurrentMetricsTableProps> = ({ data }) => {
                         {hasMore && (
                             <Popover
                                 content={
-                                    <div className="flex flex-wrap gap-1 max-w-[300px]">
+                                    <div className="flex flex-wrap gap-1 max-w-[300px] p-[0.5rem]">
                                         {traits.map((trait, idx) => (
                                             <ProjectTags
                                                 key={idx}
@@ -98,7 +98,7 @@ const CurrentMetricsTable: React.FC<CurrentMetricsTableProps> = ({ data }) => {
                                     </div>
                                 }
                                 title={
-                                    <span className="text-white font-medium">All Traits</span>
+                                    <span className="text-white font-medium px-[0.5rem]">All Traits</span>
                                 }
                                 trigger="hover"
                                 placement="top"

--- a/services/budadmin/src/pages/home/evaluations/index.tsx
+++ b/services/budadmin/src/pages/home/evaluations/index.tsx
@@ -218,7 +218,7 @@ const Evaluations = () => {
                         alt="Logo"
                       />
                     </div>
-                    <Text_14_600_B3B3B3>Evaluations</Text_14_600_B3B3B3>
+                    <Text_14_600_B3B3B3>Evaluations Hub</Text_14_600_B3B3B3>
                   </div>
                 ),
                 key: "3",


### PR DESCRIPTION
- Add padding to traits popover content and title
- Rename "Evaluations" tab to "Evaluations Hub"
- Improve visual spacing in CurrentMetricsTable popover

🤖 Generated with [Claude Code](https://claude.ai/code)