### PR TITLE
fix: Update evaluation filtering to use server-side filtering with co…

### DIFF
--- a/services/budadmin/src/hooks/useEvaluations.tsx
+++ b/services/budadmin/src/hooks/useEvaluations.tsx
@@ -175,7 +175,7 @@ export const useEvaluations = create<{
       if (payload?.language) params.append('language', payload.language);
       if (payload?.domains) params.append('domains', payload.domains);
       if (payload?.trait_ids && payload.trait_ids.length > 0) {
-        payload.trait_ids.forEach(id => params.append('trait_ids', id));
+        params.append('trait_ids', payload.trait_ids.join(','));
       }
 
       const queryString = params.toString();

--- a/services/budadmin/src/pages/home/evaluations/evalListing/index.tsx
+++ b/services/budadmin/src/pages/home/evaluations/evalListing/index.tsx
@@ -73,32 +73,28 @@ const EvaluationList = () => {
     );
   }, []);
 
-  const filteredEvaluations = useMemo(() => {
-    const searchLower = searchValue.toLowerCase();
-    return evaluationsList?.filter((evaluation) => {
-      const matchesSearch =
-        evaluation.name.toLowerCase().includes(searchLower) ||
-        evaluation.description.toLowerCase().includes(searchLower);
-      const matchesFilter =
-        selectedFilters.length === 0 ||
-        evaluation.traits?.some((trait) =>
-          selectedFilters.includes(trait.name),
-        );
-      return matchesSearch && matchesFilter;
-    });
-  }, [searchValue, selectedFilters, evaluationsList]);
+  // No longer need local filtering - use evaluationsList directly
+  const filteredEvaluations = evaluationsList;
 
   useEffect(() => {
     const fetchEvaluations = async () => {
+      // Find trait IDs for selected filter names
+      const selectedTraitIds = selectedFilters.length > 0
+        ? traitsList
+            .filter(trait => selectedFilters.includes(trait.name))
+            .map(trait => trait.id)
+        : [];
+
       const payload: GetEvaluationsPayload = {
         page: 1,
         limit: 500,
         name: searchValue,
+        trait_ids: selectedTraitIds.length > 0 ? selectedTraitIds : undefined,
       };
       await getEvaluations(payload);
     };
     fetchEvaluations();
-  }, [searchValue, getEvaluations]);
+  }, [searchValue, selectedFilters, traitsList, getEvaluations]);
 
   useEffect(() => {
     getTraits();


### PR DESCRIPTION
…mma-separated trait IDs

- Modified getEvaluations to send multiple trait_ids as comma-separated string
- Changed evalListing to pass selected trait IDs to API instead of local filtering
- Removed client-side filtering logic in favor of server-side filtering

🤖 Generated with [Claude Code](https://claude.ai/code)