### PR TITLE
fix(budcluster): remove unnecessary image_pull_secrets from model transfer

### DIFF
--- a/services/budcluster/budcluster/cluster_ops/kubernetes.py
+++ b/services/budcluster/budcluster/cluster_ops/kubernetes.py
@@ -482,8 +482,6 @@ class KubernetesHandler(BaseClusterHandler):
             # For non-NFS volume types, ensure nfs_server is defined but empty
             values["nfs_server"] = ""
 
-        values["image_pull_secrets"] = self.get_image_pull_secret()
-
         result = self.ansible_executor.run_playbook(
             playbook="MODEL_TRANSFER", extra_vars={"kubeconfig_content": self.config, **values}
         )


### PR DESCRIPTION
## Summary
- Removed unnecessary `image_pull_secrets` assignment from the model transfer workflow
- The image_pull_secrets are only required for runtime deployment, not model transfer jobs
- Simplified test code by removing redundant mock calls

## Changes Made
1. **KubernetesHandler.transfer_model()**: Removed the line that assigns `image_pull_secrets`
2. **Tests**: Updated test_model_transfer_storage_class.py to remove `get_image_pull_secret` mocks
3. **Code Cleanup**: Simplified test structure by removing unnecessary nested context managers

## Test Plan
- [x] All existing tests pass
- [x] Pre-commit hooks pass
- [x] Model transfer functionality works without image_pull_secrets assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)